### PR TITLE
Vtpm poc ww29.4

### DIFF
--- a/tpm/platform/include/TpmContext.h
+++ b/tpm/platform/include/TpmContext.h
@@ -689,17 +689,18 @@ EXTERN FailFunction    *LibFailCallback;
 #endif
 
 // This is a PoC, so we design an array to simplify the implementation
+typedef __uint128_t UINT128;
+
 #if defined TPM_CONTEXT_C
-extern UINT32          g_CurrentTpmContextId;
+extern UINT128         g_CurrentTpmContextId;
 extern UINT32          g_CurrentTpmContextCnt;
-extern UINT32          g_TpmContextIdList[MAX_TPM_CONTEXT_COUNT];
+extern UINT128         g_TpmContextIdList[MAX_TPM_CONTEXT_COUNT];
 extern TPM_CONTEXT     g_TpmContextContentList[MAX_TPM_CONTEXT_COUNT];
 #endif
 
-
 void
 SwitchTpmContext(
-    uint32_t  contextId
+    UINT128  contextId
 );
 
 uint64_t

--- a/tpm/platform/include/TpmContext.h
+++ b/tpm/platform/include/TpmContext.h
@@ -713,4 +713,9 @@ ReadTsc(
   void
 );
 
+uint64_t
+GetTscFreq(
+  void
+);
+
 #endif

--- a/tpm/platform/include/prototypes/Platform_fp.h
+++ b/tpm/platform/include/prototypes/Platform_fp.h
@@ -508,7 +508,7 @@ _plat__RunCommand(
     unsigned char   *request,       // IN: command buffer
     uint32_t        *responseSize,  // IN/OUT: response buffer size
     unsigned char   **response,     // IN/OUT: response buffer
-    uint32_t         contextId
+    __uint128_t      contextId
 );
 
 //***_plat__Fail()
@@ -538,12 +538,12 @@ _plat__GetUnique(
 
 LIB_EXPORT int
 _plat__TPM_Terminate(
-    uint32_t        contextId
+    __uint128_t     contextId
 );
 
 LIB_EXPORT int
 _plat__TPM_Initialize(
-    uint32_t        contextId,
+    __uint128_t     contextId,
     int             firstTime       // IN: indicates if this is the first call from
                                     //     main()
 );

--- a/tpm/platform/include/prototypes/Platform_fp.h
+++ b/tpm/platform/include/prototypes/Platform_fp.h
@@ -558,4 +558,9 @@ _plat__SwitchTimeUsed(
     void
 );
 
+LIB_EXPORT uint64_t
+_plat__GetTscFreq(
+    void
+);
+
 #endif  // _PLATFORM_FP_H_

--- a/tpm/platform/src/RunCommand.c
+++ b/tpm/platform/src/RunCommand.c
@@ -72,7 +72,7 @@ _plat__RunCommand(
     unsigned char   *request,       // IN: command buffer
     uint32_t        *responseSize,  // IN/OUT: response buffer size
     unsigned char   **response,      // IN/OUT: response buffer
-    uint32_t         contextId
+    __uint128_t      contextId
     )
 {
     // setjmp(s_jumpBuffer);
@@ -96,7 +96,7 @@ _plat__Fail(
 
 LIB_EXPORT int
 _plat__TPM_Terminate(
-    uint32_t        contextId
+    __uint128_t        contextId
 )
 {
     SwitchTpmContext(contextId);
@@ -126,7 +126,7 @@ _plat__ReadTsc(
 
 LIB_EXPORT int
 _plat__TPM_Initialize(
-    uint32_t        contextId,
+    __uint128_t     contextId,
     int             firstTime       // IN: indicates if this is the first call from
                                     //     main()
 )

--- a/tpm/platform/src/RunCommand.c
+++ b/tpm/platform/src/RunCommand.c
@@ -124,6 +124,15 @@ _plat__ReadTsc(
     return ReadTsc();
 }
 
+LIB_EXPORT uint64_t
+_plat__GetTscFreq(
+    void
+)
+{
+    return GetTscFreq();
+}
+
+
 LIB_EXPORT int
 _plat__TPM_Initialize(
     __uint128_t     contextId,

--- a/tpm/platform/src/TpmContext.c
+++ b/tpm/platform/src/TpmContext.c
@@ -11,9 +11,9 @@
 #include "PlatformData.h"
 #include "TpmContext.h"
 
-UINT32 g_CurrentTpmContextId = 0;
+UINT128 g_CurrentTpmContextId = 0;
 UINT32 g_CurrentTpmContextCnt = 0;
-UINT32 g_TpmContextIdList[MAX_TPM_CONTEXT_COUNT] = {0};
+UINT128 g_TpmContextIdList[MAX_TPM_CONTEXT_COUNT] = {0};
 TPM_CONTEXT g_TpmContextContentList[MAX_TPM_CONTEXT_COUNT] = {0};
 uint64_t g_TpmContextSwitchTime = 0;
 
@@ -591,7 +591,7 @@ void _SavePopContext(TPM_CONTEXT *context, BOOL save)
 }
 
 void PopTpmContext(
-    UINT32 contextId)
+    UINT128 contextId)
 {
   int i = 0;
   TPM_CONTEXT *context = NULL;
@@ -629,7 +629,7 @@ void PopTpmContext(
 }
 
 void SaveTpmContext(
-    UINT32 contextId)
+    UINT128 contextId)
 {
   int i = 0;
   TPM_CONTEXT *context = NULL;
@@ -698,7 +698,7 @@ GetSwitchTimeUsed(
 }
 
 void SwitchTpmContext(
-    UINT32 contextId)
+    UINT128 contextId)
 {
   uint64_t start, end;
 

--- a/tpm/platform/src/TpmContext.c
+++ b/tpm/platform/src/TpmContext.c
@@ -690,6 +690,31 @@ ReadTsc(
 }
 
 uint64_t
+GetTscFreq(
+  void
+)
+{
+  uint32_t eax = 0, ebx = 0, ecx = 0, edx = 0;
+  uint32_t leaf = 0x15;
+
+  __asm__ volatile (
+    "xor %%ecx, %%ecx\n"
+    "cpuid\n"
+    : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx)
+    : "a"(leaf)
+  );
+
+  if (eax == 0 || ebx == 0)
+  {
+    return 0;
+  }
+  else
+  {
+    return (uint64_t)((uint64_t)ecx * (uint64_t)ebx) / (uint64_t)eax;
+  }
+}
+
+uint64_t
 GetSwitchTimeUsed(
     void
 )


### PR DESCRIPTION
There are 2 changes in this PR:
1. Update the context_id from u32 to u128. This is because we now use 16-bytes to identify a unique UserTD.
2. Add _plat__GetTscFreq(). It returns the TSC frequency and is used for Performance test.