### PR TITLE
Fix the asm build error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,8 @@
 #![no_std]
-#![feature(asm)]
 #![feature(naked_functions)]
 
 extern crate alloc;
-
+use core::arch::asm;
 #[no_mangle]
 pub extern "C" fn __fw_debug_msg(msg: *const u8, len: usize) {
     let msg = unsafe {


### PR DESCRIPTION
After rustc is updated to nightly-2022-05-15, #![feature(asm)] is not needed anymore. Instead use core::arch::asm should be added.

Signed-off-by: Min M Xu <min.m.xu@intel.com>