### PR TITLE
Add build flag in Makefile to set MAX_TPM_CONTEXT_COUNT

### DIFF
--- a/tpm/Makefile
+++ b/tpm/Makefile
@@ -10,6 +10,9 @@ CFLAGS += ${LLVM_TARGET_ARCH} ${DEFINED} ${INCLUDES} \
 	-mno-red-zone -mcmodel=small \
 	-fno-builtin -fno-stack-protector
 
+## Set the max tpm instance count.
+CFLAGS += -DMAX_TPM_CONTEXT_COUNT=256
+
 PLATFORM_C := $(wildcard platform/src/*.c) $(wildcard ../openssl-stubs/rand_pool.c)
 PLATFORM_H := $(wildcard platform/include/*.h) $(wildcard platform/include/**/*.h)
 PLATFORM_OBJ = $(PLATFORM_C:.c=.o)

--- a/tpm/platform/include/TpmContext.h
+++ b/tpm/platform/include/TpmContext.h
@@ -6,7 +6,9 @@
 #ifndef TPM_CONTEXT_H
 #define TPM_CONTEXT_H
 
-#define MAX_TPM_CONTEXT_COUNT   16
+#ifndef MAX_TPM_CONTEXT_COUNT
+#define MAX_TPM_CONTEXT_COUNT   256
+#endif
 
 #if defined TPM_CONTEXT_C
 // The following arrays are used to save command sessions information so that the


### PR DESCRIPTION
Issue #10 

A TPM_CONTEXT represents a vTPM intance. Currently we use an array to host the TPM_CONTEXT. Its size is fixed (MAX_TPM_CONTEXT_COUNT). The benefit of using a fixed size array is that it will never fail because of out_of_memory in run-time. But it is not flexible that the array size has to be changed in source code.

This patch adds a build flag to set MAX_TPM_CONTEXT_COUNT. Its default value is 256.