### PR TITLE
Add _plat__GetMaxTpmContextCount

### DIFF
--- a/tpm/platform/include/prototypes/Platform_fp.h
+++ b/tpm/platform/include/prototypes/Platform_fp.h
@@ -563,4 +563,9 @@ _plat__GetTscFreq(
     void
 );
 
+LIB_EXPORT uint32_t
+_plat__GetMaxTpmContextCount(
+    void
+);
+
 #endif  // _PLATFORM_FP_H_

--- a/tpm/platform/src/RunCommand.c
+++ b/tpm/platform/src/RunCommand.c
@@ -132,6 +132,13 @@ _plat__GetTscFreq(
     return GetTscFreq();
 }
 
+LIB_EXPORT uint32_t
+_plat__GetMaxTpmContextCount(
+    void
+)
+{
+    return MAX_TPM_CONTEXT_COUNT;
+}
 
 LIB_EXPORT int
 _plat__TPM_Initialize(


### PR DESCRIPTION
Issue #11
Caller needs a way to know the max tpm context count.