### PR TITLE
Add 2 APIs to wrap tpm initialize/terminate

### DIFF
--- a/tpm/platform/include/prototypes/Platform_fp.h
+++ b/tpm/platform/include/prototypes/Platform_fp.h
@@ -535,4 +535,15 @@ _plat__GetUnique(
     unsigned char       *b              // output buffer
 );
 
+LIB_EXPORT int
+_plat__TPM_Terminate(
+    void
+);
+
+LIB_EXPORT int
+_plat__TPM_Initialize(
+    int             firstTime       // IN: indicates if this is the first call from
+                                    //     main()
+);
+
 #endif  // _PLATFORM_FP_H_

--- a/tpm/platform/src/RunCommand.c
+++ b/tpm/platform/src/RunCommand.c
@@ -52,6 +52,7 @@
 #include "Platform.h"
 // #include <setjmp.h>
 #include "ExecCommand_fp.h"
+#include "Manufacture_fp.h"
 
 // jmp_buf              s_jumpBuffer;
 
@@ -89,3 +90,33 @@ _plat__Fail(
     printf("plat fail deadloop");
     for(;;);
 }
+
+LIB_EXPORT int
+_plat__TPM_Terminate(
+    void
+)
+{
+    TPM_TearDown();
+    _plat__Signal_PowerOn();
+    _plat__Signal_Reset();
+
+    return 0;
+}
+
+LIB_EXPORT int
+_plat__TPM_Initialize(
+    int             firstTime       // IN: indicates if this is the first call from
+                                    //     main()
+)
+{
+    _plat__Signal_PowerOff();
+    _plat__NVEnable(NULL);
+    TPM_Manufacture(firstTime);
+
+    _plat__Signal_PowerOn();
+    _plat__SetNvAvail();
+    _plat__NvCommit();
+
+    return 0;
+}
+


### PR DESCRIPTION
To initialize or terminate a TPM chip there are a serial of functions to be called. This patch wraps these functions into below 2 functions:
 - _plat__TPM_Initialize
 - _plat__TPM_Terminate