### PR TITLE
Add platParameter in _plat__TPM_Initialize as input parameter

### DIFF
--- a/tpm/platform/include/prototypes/Platform_fp.h
+++ b/tpm/platform/include/prototypes/Platform_fp.h
@@ -542,8 +542,9 @@ _plat__TPM_Terminate(
 
 LIB_EXPORT int
 _plat__TPM_Initialize(
-    int             firstTime       // IN: indicates if this is the first call from
-                                    //     main()
+    int             firstTime,       // IN: indicates if this is the first call from
+                                     //     main()
+    void            *platParameter  // IN: platform parameters
 );
 
 #endif  // _PLATFORM_FP_H_

--- a/tpm/platform/src/NVMem.c
+++ b/tpm/platform/src/NVMem.c
@@ -176,7 +176,7 @@ _plat__NvErrors(
 //      <0          if unrecoverable error
 LIB_EXPORT int
 _plat__NVEnable(
-    void            *platParameter  // IN: platform specific parameters
+    void            *platParameter    // IN: platform specific parameters
     )
 {
     NOT_REFERENCED(platParameter);          // to keep compiler quiet
@@ -186,6 +186,11 @@ _plat__NVEnable(
     s_NV_recoverable = FALSE;
 
     _plat__NvMemoryClear(0, NV_MEMORY_SIZE);
+
+    if (platParameter != NULL) {
+        memcpy(s_NV, platParameter, NV_MEMORY_SIZE);
+    }
+
 #if FILE_BACKED_NV
     if(s_NvFile != NULL)
         return 0;

--- a/tpm/platform/src/RunCommand.c
+++ b/tpm/platform/src/RunCommand.c
@@ -105,12 +105,13 @@ _plat__TPM_Terminate(
 
 LIB_EXPORT int
 _plat__TPM_Initialize(
-    int             firstTime       // IN: indicates if this is the first call from
-                                    //     main()
+    int             firstTime,       // IN: indicates if this is the first call from
+                                     //     main()
+    void            *platParameter
 )
 {
     _plat__Signal_PowerOff();
-    _plat__NVEnable(NULL);
+    _plat__NVEnable(platParameter);
     TPM_Manufacture(firstTime);
 
     _plat__Signal_PowerOn();


### PR DESCRIPTION
Fix #18

In the previous implementation NVM is backed up in a file. When a TPM instance is initialized, the NVM is restored from a file. But file system is not supported in vtpm-td. So the NVM is backed up in memory which is managed by vtpm-td. When TPM instance is initialized, the NVM content is sent back to the TPM instance so that NVM can be restored.

This patch adds a new input parameter (platParameter) in _plat__TPM_Initialize so that it can then passed to _plat__NVEnable.